### PR TITLE
Make MIN_PEER_PROTO_VERSION = PROTOCOL_VERSION

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -19,7 +19,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 70077;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 70209;
+static const int MIN_PEER_PROTO_VERSION = PROTOCOL_VERSION;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
We should be dropping old nodes while still testing and upping the version -- bad things can happen to the chain otherwise.